### PR TITLE
docs: deduplicate README warning banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 
 A definitive security practice guide designed specifically for **High-Privilege Autonomous AI Agents** (OpenClaw). It shifts the paradigm from traditional "host-based static defense" to "Agentic Zero-Trust Architecture", effectively mitigating risks like destructive operations, prompt injection, supply chain poisoning, and high-risk business logic execution.
 
-⚠️Before you start playing, please read the disclaimer and FAQ at the bottom.<br>
-⚠️Before you start playing, please read the disclaimer and FAQ at the bottom.<br>
 ⚠️Before you start playing, please read the disclaimer and FAQ at the bottom.
 
 ## 🎯 Scope, Scenario & Core Principles


### PR DESCRIPTION
## Summary

- remove the duplicated warning banner lines at the top of `README.md`
- keep the intended disclaimer wording intact, but display it only once for readability
- keep this PR independent from the open nightly backup script line in `#3`

## Validation

- static check confirmed the warning sentence now appears exactly once in `README.md`
- diff is limited to removing the duplicated lines