### PR TITLE
docs: respect custom state dir in cron example

### DIFF
--- a/docs/OpenClaw-Security-Practice-Guide.md
+++ b/docs/OpenClaw-Security-Practice-Guide.md
@@ -133,7 +133,7 @@ openclaw cron add \
   --cron "0 3 * * *" \
   --tz "<your-timezone>" \ # e.g., Asia/Shanghai, America/New_York
   --session "isolated" \
-  --message "Execute this command and output the result as-is, no extra commentary: bash ~/.openclaw/workspace/scripts/nightly-security-audit.sh" \
+  --message "Execute this command and output the result as-is, no extra commentary: bash ${OPENCLAW_STATE_DIR:-$HOME/.openclaw}/workspace/scripts/nightly-security-audit.sh" \
   --announce \
   --channel <channel> \ # telegram, discord, signal, etc.
   --to <your-chat-id> \ # Your chatId (NOT username)

--- a/docs/OpenClaw极简安全实践指南.md
+++ b/docs/OpenClaw极简安全实践指南.md
@@ -133,7 +133,7 @@ openclaw cron add \
   --cron "0 3 * * *" \
   --tz "<your-timezone>" \                    # 例：Asia/Shanghai、America/New_York
   --session "isolated" \
-  --message "Execute this command and output the result as-is, no extra commentary: bash ~/.openclaw/workspace/scripts/nightly-security-audit.sh" \
+  --message "Execute this command and output the result as-is, no extra commentary: bash ${OPENCLAW_STATE_DIR:-$HOME/.openclaw}/workspace/scripts/nightly-security-audit.sh" \
   --announce \
   --channel <channel> \                       # telegram、discord、signal 等
   --to <your-chat-id> \                       # 你的 chatId（非用户名）


### PR DESCRIPTION
## Summary

- replace the hardcoded `~/.openclaw/workspace/...` cron `--message` example with the documented `${OPENCLAW_STATE_DIR:-$HOME/.openclaw}` path form
- keep the English and Chinese guides aligned with the `$OC=${OPENCLAW_STATE_DIR:-$HOME/.openclaw}` convention they already describe earlier in the docs
- scope the PR to the two guide docs only, independent from the open backup-script and README warning PRs

## Validation

- static check confirmed both guide docs now use the `${OPENCLAW_STATE_DIR:-$HOME/.openclaw}` path in the cron `--message` example
- static check confirmed the old hardcoded `bash ~/.openclaw/workspace/scripts/nightly-security-audit.sh` string is gone from both docs